### PR TITLE
Switch include/exclude filters to arrays and use minimatch directly

### DIFF
--- a/lib/hashly.js
+++ b/lib/hashly.js
@@ -13,8 +13,8 @@ var hashcodeGenerator = require("./hashcode-generator");
 var _options;
 
 var getManifestPath = function (directory, serializer) {
-    
-    // If the manifest path is declared explicitly, 
+
+    // If the manifest path is declared explicitly,
     // use it and ignore the rest of the rules.
     if (_options.manifestPath) {
         return _options.manifestPath;
@@ -203,21 +203,18 @@ var createManifest = function (files, baseDir, targetDir, existingManifestData) 
     return data;
 };
 
-var processFilter = function (filter) {
-    if (!filter) {
+var processFilter = function (filters) {
+    if (!filters) {
         return null;
     }
-    var filters = filter.split(",").map(function (s) {
-        return s.trim();
-    });
+
+    if (typeof filters == "string") {
+        filters = [filters];
+    }
 
     return function (filePath) {
         for (var i = 0; i < filters.length; i++) {
-            if (filters[i].indexOf("*") < 0) {
-                if (filePath.toLowerCase().indexOf(filters[i]) >= 0) {
-                    return true;
-                }
-            } else if (minimatch(path.basename(filePath), filters[i])) {
+            if (minimatch(filePath, filters[i])) {
                 return true;
             }
         }
@@ -436,7 +433,7 @@ exports.cleanOld = function (directory, options) {
             if (fileSet[filePath]) {
                 return;
             }
-            
+
             if (options.cleanOldDays > 0) {
                 var stat = fsutil.statSync(filePath);
                 if (stat.mtime >= oldestAllowed) {


### PR DESCRIPTION
I wanted to use glob statements like this: `**/public/img/**/*.*`, `**/public/{js,css}/app/*.{js,css}` but the existing filter handling would split the second filter at the commas and would also not use minimatch because of the asterisks. I changed the implementation to take an array of filters: `--include="filterA" --include="filterB"`, rather than splitting on commas, and to use minimatch directly rather than handling asterisks differently.

Let me know if my implementation misses any desired behavior.
