### PR TITLE
Add support --base-dir argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ options:
   -e, --exclude            A globbing expression. Any matching files will not be processed. Takes precedence over --include.
   -m, --manifest-format    The format for the manifest file. Currently supports "json" or "tab" (tab delimited). 
                                Default is "json"
+  -b, --base-dir           Specifies the path to a folder. If specified, all paths included in the manifest will be 
+                               relative to this path.
   --manifest-path          Specifies a path for the manifest file. If not specified, the manifest is named "manifest.{ext}"
                                and is placed in the destination directory root.
   -a, --amend              Instructs hashly to amend an existing manifest, where it would normally delete and recreate it

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -38,7 +38,7 @@ function readStdin(stdin, cwd, callback) {
 function processArgs(argv, cwd) {
     var args = minimist(argv.slice(2), {
         "boolean": ["verbose", "clean", "ignore-errors", "help", "skip-css", "amend", "quickhash"],
-        "string": ["exclude", "include", "manifest-format", "manifest-path", "plugins", "clean-old"],
+        "string": ["exclude", "include", "manifest-format", "manifest-path", "plugins", "clean-old", "base-dir"],
         "alias": {
             "verbose": "v",
             "clean": "c",
@@ -49,7 +49,8 @@ function processArgs(argv, cwd) {
             "plugins": "p",
             "skip-css": "s",
             "amend": "a",
-            "quickhash": "q"
+            "quickhash": "q",
+			"base-dir": "b"
         }
     });
 
@@ -80,7 +81,8 @@ function processArgs(argv, cwd) {
         processCss: !args["skip-css"],
         quickhash: args["quickhash"],
         amend: args["amend"],
-        cleanOldDays: parseInt(args["clean-old"])
+        cleanOldDays: parseInt(args["clean-old"]),
+		baseDir: args["base-dir"]
     };
 
     return {

--- a/lib/hashly.js
+++ b/lib/hashly.js
@@ -92,6 +92,13 @@ var createManifestEntryCss = function (fullPath, basePath, targetDir, data) {
     return entry;
 };
 
+
+var isDescendent = function (childPath, baseDir)  {
+	// TODO should be case insensitive on windows
+    return childPath.indexOf(baseDir) === 0;
+}
+
+
 var processEntry = function (fullPath, baseDir, targetDir, data) {
 
     // See if an existing entry exists in the cache
@@ -100,10 +107,9 @@ var processEntry = function (fullPath, baseDir, targetDir, data) {
         return existingEntry;
     }
 
-    // TODO should be case insensitive on windows
     // TODO consider an optimization to skip this if the files were
     // gathered internally.
-    if (fullPath.indexOf(baseDir) !== 0) {
+    if (!isDescendent(fullPath, baseDir)) {
         throw new Error("The file '" + fullPath + "' is not in the base directory: '" + baseDir + "'");
     }
 
@@ -378,6 +384,14 @@ exports.processDirectory = function (sourceDir, targetDir, options) {
         files.push(file);
     });
 
+	if ( options.baseDir ) {
+		if (!isDescendent(sourceDir, options.baseDir)) {
+			throw new Error("The source directory '" + sourceDir + "' is not in the base directory: '" + options.baseDir + "'");
+		}
+		// Adjust sourceDir so full paths relative to the base folder will be written to the manifest.
+		sourceDir = options.baseDir;
+	}
+	
     return exports.processFiles(files, sourceDir, targetDir, options);
 };
 

--- a/lib/usage.txt
+++ b/lib/usage.txt
@@ -12,6 +12,8 @@ options:
   -e, --exclude            A globbing expression. Any matching files will not be processed. Takes precedence over --include.
   -m, --manifest-format    The format for the manifest file. Currently supports "json" or "tab" (tab delimited). 
                                Default is "json"
+  -b, --base-dir           Specifies the path to a folder. If specified, all paths included in the manifest will be 
+                               prefixed with this path.
   --manifest-path          Specifies a path for the manifest file. If not specified, the manifest is named "manifest.{ext}"
                                and is placed in the destination directory root.
   -a, --amend              Instructs hashly to amend an existing manifest, where it would normally delete and recreate it

--- a/test/cli.unittests.js
+++ b/test/cli.unittests.js
@@ -53,5 +53,10 @@ describe("cli", function () {
             assert.equal(unixify(result.sourceDir), "/a/b/c/sourcedir");
             assert.equal(unixify(result.targetDir), "/a/b/c/sourcedir");
         });
+
+        it("should return baseDir args --base-dir passed", function () {
+            var result = runProcessArgs(["/a/b/c", "--base-dir=/a"]);
+            assert.equal(result.options.baseDir, "/a");
+        });
     });
 });


### PR DESCRIPTION
It's handy to be able to process a (sub)folder with hashly, yet have the manifest contain entries with root relative paths.
