### PR TITLE
Stronger regular expression for determining if a path is a hashed file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules
 temp
 .DS_Store
 *.sublime-workspace
+.ntvs_analysis.dat
+*.njsproj
+*.sln
+*.suo
+obj

--- a/lib/hash-pattern.js
+++ b/lib/hash-pattern.js
@@ -2,7 +2,8 @@
 
 var path = require("path");
 
-var _hashedFileRegex = (/.*\-hc[^\.].*/i);
+// We use MD5 hashcodes which are length 32 string containing only hexadecimal chars.
+var _hashedFileRegex = (/.*\-hc[a-f0-9]{32}.*/i);
 
 // Determines if a filename is a hashed (generated) path, or an original path
 exports.isHashedFile = function (fileName) {

--- a/test/hash-pattern.unittests.js
+++ b/test/hash-pattern.unittests.js
@@ -8,17 +8,25 @@ describe("hash-pattern", function () {
     describe("#isHashedFile()", function () {
 
         it("should return true for a full hashed path", function () {
-            assert.isTrue(hashpattern.isHashedFile("/foo/bar/baz/blah-hc12345.js"));
+            assert.isTrue(hashpattern.isHashedFile("/foo/bar/baz/blah-hc1234567890abcdef1234567890abcdef.js"));
         });
-
+        
         it("should return true for a hashed file name", function () {
-            assert.isTrue(hashpattern.isHashedFile("blah-hc12345.js"));
+            assert.isTrue(hashpattern.isHashedFile("blah-hc1234567890abcdef1234567890abcdef.js"));
         });
-
+        
+        it("should return false for a non-hashed file name that is similar to a hashed file name", function () {
+            assert.isFalse(hashpattern.isHashedFile("blah-hc-1234567890abcdef1234567890abcdef.js"));
+        });
+        
         it("should return false for a full, non-hashed path", function () {
             assert.isFalse(hashpattern.isHashedFile("/foo/bar/baz/blah.js"));
         });
-
+        
+        it("should return false for a full, non-hashed path similar to a hashed file name", function () {
+            assert.isFalse(hashpattern.isHashedFile("/foo/bar/baz/blah-hc-1234567890abcdef1234567890abcdef.js"));
+        });
+        
         it("should return false for a non-hashed filename", function () {
             assert.isFalse(hashpattern.isHashedFile("blah.js"));
         });


### PR DESCRIPTION
File names that legitimately contain -hc (for example foo-hc-bar.js) will be erroneously flagged as a hashed file using the current regular expression.  

Matching against 32 hexadecimal chars (that is, an MD5 hashcode) in the regex should avoid this problem.
