### PR TITLE
fixes an issue with relative urls in css

### DIFF
--- a/lib/hashly.js
+++ b/lib/hashly.js
@@ -74,7 +74,11 @@ var createManifestEntryCss = function(fullPath, baseDir, targetDir, data) {
         }
 
         if (!isRootRelative) {
-            return path.relative(path.dirname(fullPath), entry.hashedPathPhysical);
+            // find path of target css file to build correct relative path to hashed resource
+            var relativePath = path.relative(baseDir, fullPath);
+            var targetPath = path.resolve(targetDir, relativePath);
+            
+            return path.relative(path.dirname(targetPath), entry.hashedPathPhysical);
         }
         return entry.hashedPath;
     };


### PR DESCRIPTION
if you're using hashly e.g. like `hashly build/assets dist/assets`, and you're using relative paths in css e.g. like `url(../fonts/icons.eot)` there was an issue with wrong relative paths. They looked like `url(../../../dist/assets/fonts/icons.eot)`.

This happened because the reference path for the css was the source path of the css (build/assets/css/) and not the target path (dist/assets/css/).