### PR TITLE
Fix abbreviation for --include option

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -42,9 +42,9 @@ function processArgs(argv, cwd) {
         "alias": {
             "verbose": "v",
             "clean": "c",
+            "include": "i",
             "exclude": "e",
             "manifest-format": "m",
-            "ignore-errors": "i",
             "help": "h",
             "plugins": "p",
             "skip-css": "s",


### PR DESCRIPTION
The README and usage text state that `-i` is the abbreviation for `--include` but the code actually mapped `-i` to `--ignore-errors`.