### PR TITLE
Add Symfony support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ options:
   --passthrough            A globbing expression. Any matching files will be copied as-is to the destination folder.
                                Has no effect if the destination is the same as the source.
   -m, --manifest-format    The format for the manifest file. Currently supports "json", "json-object" (json with original
-                               path as key) or "tab" (tab delimited).
+                               path as key), "json-symfony" (for use with symfony asset versioning), or "tab" (tab delimited).
                                Default is "json".
   -b, --base-dir           Specifies the path to a folder. If specified, all paths included in the manifest will be
                                relative to this path.

--- a/lib/manifest-writer-json-symfony.js
+++ b/lib/manifest-writer-json-symfony.js
@@ -1,0 +1,23 @@
+"use strict";
+
+exports.name = "json-symfony";
+
+exports.extension = ".json";
+
+exports.serialize = function(manifestData) {
+    var manifestObject = {};
+    manifestData.forEach(function(entry) {
+                manifestObject[entry.path] = entry.hashedPath;
+            });
+    return JSON.stringify(manifestObject, null, 4);
+};
+
+exports.parse = function(serialized) {
+    var manifestObject = JSON.parse(serialized);
+    var manifestData = [];
+    manifestObject.forEach(function(entry, key) {
+                manifestData.push(key);
+            });
+
+    return manifestData;
+};

--- a/lib/manifest-writer-json-symfony.js
+++ b/lib/manifest-writer-json-symfony.js
@@ -13,7 +13,7 @@ exports.extension = ".json";
 /**
  * Format manifest.json for use with symfony asset versioning
  *
- * Example: output
+ * Example output:
  * {
  *     "/assets/bundle/app.css": "/assets/bundle/app-hc21219d6ba2d498e783661d6fc87cda05.css",
  *    "/assets/bundle/app.js": "/assets/bundle/app-hc56c505dbada50f259e092bc07a43286d.js"

--- a/lib/manifest-writer-json-symfony.js
+++ b/lib/manifest-writer-json-symfony.js
@@ -1,23 +1,45 @@
 "use strict";
 
+/**
+ * @type {string}
+ */
 exports.name = "json-symfony";
 
+/**
+ * @type {string}
+ */
 exports.extension = ".json";
 
-exports.serialize = function(manifestData) {
+/**
+ * Format manifest.json for use with symfony asset versioning
+ *
+ * Example: output
+ * {
+ *     "/assets/bundle/app.css": "/assets/bundle/app-hc21219d6ba2d498e783661d6fc87cda05.css",
+ *    "/assets/bundle/app.js": "/assets/bundle/app-hc56c505dbada50f259e092bc07a43286d.js"
+ * }
+ *
+ * @param manifestData
+ * @returns {string}
+ */
+exports.serialize = function (manifestData) {
     var manifestObject = {};
-    manifestData.forEach(function(entry) {
-                manifestObject[entry.path] = entry.hashedPath;
-            });
+    manifestData.forEach(function (entry) {
+        manifestObject[entry.path] = entry.hashedPath;
+    });
     return JSON.stringify(manifestObject, null, 4);
 };
 
-exports.parse = function(serialized) {
+/**
+ * @param serialized
+ * @returns {Array}
+ */
+exports.parse = function (serialized) {
     var manifestObject = JSON.parse(serialized);
     var manifestData = [];
-    manifestObject.forEach(function(entry, key) {
-                manifestData.push(key);
-            });
+    manifestObject.forEach(function (entry, key) {
+        manifestData.push(key);
+    });
 
     return manifestData;
 };

--- a/lib/serializer-factory.js
+++ b/lib/serializer-factory.js
@@ -4,7 +4,8 @@
 var _manifestFormats = {
     "json": true,
     "tab": true,
-    "json-object": true
+    "json-object": true,
+    "json-symfony": true
 };
 
 // Gets the correct serializer for the specified manifest format


### PR DESCRIPTION
Added `json-symfony` manifest format as Symfony asset versioning expects a different format than `json-object` provides.

json-object:
```
{
    "/assets/bundle/app.css": {
        "path": "/assets/bundle/app-hc21219d6ba2d498e783661d6fc87cda05.css"
    },
    "/assets/bundle/app.js": {
        "path": "/assets/bundle/app-hc56c505dbada50f259e092bc07a43286d.js"
    }
}
```

json-symfony:
```
{
    "/assets/bundle/app.css": "/assets/bundle/app-hc21219d6ba2d498e783661d6fc87cda05.css",
    "/assets/bundle/app.js": "/assets/bundle/app-hc56c505dbada50f259e092bc07a43286d.js"
}
```